### PR TITLE
Migrate to .NET Core 3.1

### DIFF
--- a/Casey.TraySystemMonitor.Biz/Casey.TraySystemMonitor.Biz.csproj
+++ b/Casey.TraySystemMonitor.Biz/Casey.TraySystemMonitor.Biz.csproj
@@ -1,22 +1,9 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="12.0">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <ProductVersion>8.0.50727</ProductVersion>
-    <SchemaVersion>2.0</SchemaVersion>
-    <ProjectGuid>{7578B6FE-B524-4CC1-A67C-CAC9E4429170}</ProjectGuid>
-    <OutputType>Library</OutputType>
-    <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>Casey.TraySystemMonitor.Biz</RootNamespace>
-    <AssemblyName>Casey.TraySystemMonitor.Biz</AssemblyName>
-    <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
-    <FileUpgradeFlags>
-    </FileUpgradeFlags>
-    <UpgradeBackupLocation>
-    </UpgradeBackupLocation>
-    <OldToolsVersion>2.0</OldToolsVersion>
-    <TargetFrameworkProfile />
+    <TargetFramework>net451</TargetFramework>
+    <FileUpgradeFlags />
+    <UpgradeBackupLocation />
     <PublishUrl>publish\</PublishUrl>
     <Install>true</Install>
     <InstallFrom>Disk</InstallFrom>
@@ -32,57 +19,28 @@
     <IsWebBootstrapper>false</IsWebBootstrapper>
     <UseApplicationTrust>false</UseApplicationTrust>
     <BootstrapperEnabled>true</BootstrapperEnabled>
+    <AssemblyTitle>Casey.TraySystemMonitor.Biz</AssemblyTitle>
+    <Company>Casey Liss</Company>
+    <Product>Casey.TraySystemMonitor.Biz</Product>
+    <Copyright>Copyright © Casey Liss 2007-2015</Copyright>
+    <OutputPath>bin\$(Configuration)\</OutputPath>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <DebugSymbols>true</DebugSymbols>
+    <Description>Buisness objects and status providers for TraySystemMonitor. Debug build.</Description>
     <DebugType>full</DebugType>
-    <Optimize>false</Optimize>
-    <OutputPath>bin\Debug\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-    <Prefer32Bit>false</Prefer32Bit>
     <PlatformTarget>x86</PlatformTarget>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <Description>Buisness objects and status providers for TraySystemMonitor. Debug build.</Description>
     <DebugType>pdbonly</DebugType>
-    <Optimize>true</Optimize>
-    <OutputPath>bin\Release\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="System" />
-    <Reference Include="System.Data" />
-    <Reference Include="System.Drawing" />
     <Reference Include="System.Management" />
     <Reference Include="System.Windows.Forms" />
-    <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="BatteryStatus.cs" />
-    <Compile Include="CpuMonitor.cs" />
-    <Compile Include="DiskUsage.cs" />
-    <Compile Include="Loader.cs" />
-    <Compile Include="MemoryStatus.cs" />
-    <Compile Include="NetworkDownstream.cs" />
-    <Compile Include="NetworkUpDown.cs" />
-    <Compile Include="NetworkUpstream.cs" />
-    <Compile Include="Properties\AssemblyInfo.cs" />
-    <Compile Include="VolumeStatus.cs" />
-    <Compile Include="WirelessStrength.cs" />
-  </ItemGroup>
-  <ItemGroup>
-    <ProjectReference Include="..\Casey.TraySystemMonitor.Ext\Casey.TraySystemMonitor.Ext.csproj">
-      <Project>{96AC9B73-477A-4F57-804B-4D0C2E415E13}</Project>
-      <Name>Casey.TraySystemMonitor.Ext</Name>
-    </ProjectReference>
-    <ProjectReference Include="..\Casey.Utility\Casey.Utility.csproj">
-      <Project>{22502482-4566-4670-9d6b-8e264810eea3}</Project>
-      <Name>Casey.Utility</Name>
-    </ProjectReference>
+    <ProjectReference Include="..\Casey.TraySystemMonitor.Ext\Casey.TraySystemMonitor.Ext.csproj" />
+    <ProjectReference Include="..\Casey.Utility\Casey.Utility.csproj" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="Images\BatteryStatus.png" />
@@ -97,24 +55,4 @@
     <EmbeddedResource Include="Images\NetworkUpDown.png" />
     <EmbeddedResource Include="Images\NetworkUpstream.png" />
   </ItemGroup>
-  <ItemGroup>
-    <BootstrapperPackage Include="Microsoft.Net.Client.3.5">
-      <Visible>False</Visible>
-      <ProductName>.NET Framework 3.5 SP1 Client Profile</ProductName>
-      <Install>false</Install>
-    </BootstrapperPackage>
-    <BootstrapperPackage Include="Microsoft.Net.Framework.3.5.SP1">
-      <Visible>False</Visible>
-      <ProductName>.NET Framework 3.5 SP1</ProductName>
-      <Install>true</Install>
-    </BootstrapperPackage>
-  </ItemGroup>
-  <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
-  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
-       Other similar extension points exist, see Microsoft.Common.targets.
-  <Target Name="BeforeBuild">
-  </Target>
-  <Target Name="AfterBuild">
-  </Target>
-  -->
 </Project>

--- a/Casey.TraySystemMonitor.Biz/Casey.TraySystemMonitor.Biz.csproj
+++ b/Casey.TraySystemMonitor.Biz/Casey.TraySystemMonitor.Biz.csproj
@@ -1,7 +1,7 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   <PropertyGroup>
     <ProductVersion>8.0.50727</ProductVersion>
-    <TargetFramework>net451</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <FileUpgradeFlags />
     <UpgradeBackupLocation />
     <PublishUrl>publish\</PublishUrl>
@@ -24,6 +24,7 @@
     <Product>Casey.TraySystemMonitor.Biz</Product>
     <Copyright>Copyright © Casey Liss 2007-2015</Copyright>
     <OutputPath>bin\$(Configuration)\</OutputPath>
+    <UseWindowsForms>true</UseWindowsForms>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <Description>Buisness objects and status providers for TraySystemMonitor. Debug build.</Description>
@@ -36,7 +37,6 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System.Management" />
-    <Reference Include="System.Windows.Forms" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Casey.TraySystemMonitor.Ext\Casey.TraySystemMonitor.Ext.csproj" />
@@ -54,5 +54,8 @@
     <EmbeddedResource Include="Images\NetworkDownstream.png" />
     <EmbeddedResource Include="Images\NetworkUpDown.png" />
     <EmbeddedResource Include="Images\NetworkUpstream.png" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="System.Management" Version="4.7.0" />
   </ItemGroup>
 </Project>

--- a/Casey.TraySystemMonitor.Biz/Properties/AssemblyInfo.cs
+++ b/Casey.TraySystemMonitor.Biz/Properties/AssemblyInfo.cs
@@ -2,22 +2,6 @@
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
-// General Information about an assembly is controlled through the following 
-// set of attributes. Change these attribute values to modify the information
-// associated with an assembly.
-[assembly: AssemblyTitle("Casey.TraySystemMonitor.Biz")]
-#if DEBUG
-[assembly: AssemblyDescription("Buisness objects and status providers for TraySystemMonitor.  Debug build.")]
-#else
-[assembly: AssemblyDescription("Buisness objects and status providers for TraySystemMonitor.  Release build.")]
-#endif
-[assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("Casey Liss")]
-[assembly: AssemblyProduct("Casey.TraySystemMonitor.Biz")]
-[assembly: AssemblyCopyright("Copyright © Casey Liss 2007-2015")]
-[assembly: AssemblyTrademark("")]
-[assembly: AssemblyCulture("")]
-
 // Setting ComVisible to false makes the types in this assembly not visible 
 // to COM components.  If you need to access a type in this assembly from 
 // COM, set the ComVisible attribute to true on that type.
@@ -25,15 +9,3 @@ using System.Runtime.InteropServices;
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("b7a030f3-15fa-4c36-bb01-973ff6f7ed05")]
-
-// Version information for an assembly consists of the following four values:
-//
-//      Major Version
-//      Minor Version 
-//      Build Number
-//      Revision
-//
-// You can specify all the values or you can default the Revision and Build Numbers 
-// by using the '*' as shown below:
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/Casey.TraySystemMonitor.Ext/Casey.TraySystemMonitor.Ext.csproj
+++ b/Casey.TraySystemMonitor.Ext/Casey.TraySystemMonitor.Ext.csproj
@@ -1,22 +1,9 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="12.0">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <ProductVersion>8.0.50727</ProductVersion>
-    <SchemaVersion>2.0</SchemaVersion>
-    <ProjectGuid>{96AC9B73-477A-4F57-804B-4D0C2E415E13}</ProjectGuid>
-    <OutputType>Library</OutputType>
-    <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>Casey.TraySystemMonitor.Ext</RootNamespace>
-    <AssemblyName>Casey.TraySystemMonitor.Ext</AssemblyName>
-    <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
-    <FileUpgradeFlags>
-    </FileUpgradeFlags>
-    <UpgradeBackupLocation>
-    </UpgradeBackupLocation>
-    <OldToolsVersion>2.0</OldToolsVersion>
-    <TargetFrameworkProfile />
+    <TargetFramework>net451</TargetFramework>
+    <FileUpgradeFlags />
+    <UpgradeBackupLocation />
     <PublishUrl>publish\</PublishUrl>
     <Install>true</Install>
     <InstallFrom>Disk</InstallFrom>
@@ -32,54 +19,19 @@
     <IsWebBootstrapper>false</IsWebBootstrapper>
     <UseApplicationTrust>false</UseApplicationTrust>
     <BootstrapperEnabled>true</BootstrapperEnabled>
+    <AssemblyTitle>Casey.TraySystemMonitor.Ext</AssemblyTitle>
+    <Company>Casey Liss</Company>
+    <Product>Casey.TraySystemMonitor.Ext</Product>
+    <Copyright>Copyright © Casey Liss 2007-2015</Copyright>
+    <OutputPath>bin\$(Configuration)\</OutputPath>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <DebugSymbols>true</DebugSymbols>
+    <Description>Externally viewable assembly for TraySystemMonitor. Debug build.</Description>
     <DebugType>full</DebugType>
-    <Optimize>false</Optimize>
-    <OutputPath>bin\Debug\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-    <Prefer32Bit>false</Prefer32Bit>
     <PlatformTarget>x86</PlatformTarget>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <Description>Externally viewable assembly for TraySystemMonitor. Debug build.</Description>
     <DebugType>pdbonly</DebugType>
-    <Optimize>true</Optimize>
-    <OutputPath>bin\Release\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
-  <ItemGroup>
-    <Reference Include="System" />
-    <Reference Include="System.Drawing" />
-  </ItemGroup>
-  <ItemGroup>
-    <Compile Include="IStatusProvider.cs" />
-    <Compile Include="NetworkProvider.cs" />
-    <Compile Include="Properties\AssemblyInfo.cs" />
-  </ItemGroup>
-  <ItemGroup>
-    <BootstrapperPackage Include="Microsoft.Net.Client.3.5">
-      <Visible>False</Visible>
-      <ProductName>.NET Framework 3.5 SP1 Client Profile</ProductName>
-      <Install>false</Install>
-    </BootstrapperPackage>
-    <BootstrapperPackage Include="Microsoft.Net.Framework.3.5.SP1">
-      <Visible>False</Visible>
-      <ProductName>.NET Framework 3.5 SP1</ProductName>
-      <Install>true</Install>
-    </BootstrapperPackage>
-  </ItemGroup>
-  <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
-  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
-       Other similar extension points exist, see Microsoft.Common.targets.
-  <Target Name="BeforeBuild">
-  </Target>
-  <Target Name="AfterBuild">
-  </Target>
-  -->
 </Project>

--- a/Casey.TraySystemMonitor.Ext/Casey.TraySystemMonitor.Ext.csproj
+++ b/Casey.TraySystemMonitor.Ext/Casey.TraySystemMonitor.Ext.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <ProductVersion>8.0.50727</ProductVersion>
-    <TargetFramework>net451</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <FileUpgradeFlags />
     <UpgradeBackupLocation />
     <PublishUrl>publish\</PublishUrl>
@@ -34,4 +34,8 @@
     <Description>Externally viewable assembly for TraySystemMonitor. Debug build.</Description>
     <DebugType>pdbonly</DebugType>
   </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="System.Diagnostics.PerformanceCounter" Version="4.7.0" />
+    <PackageReference Include="System.Drawing.Common" Version="4.7.0" />
+  </ItemGroup>
 </Project>

--- a/Casey.TraySystemMonitor.Ext/Properties/AssemblyInfo.cs
+++ b/Casey.TraySystemMonitor.Ext/Properties/AssemblyInfo.cs
@@ -2,22 +2,6 @@
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
-// General Information about an assembly is controlled through the following 
-// set of attributes. Change these attribute values to modify the information
-// associated with an assembly.
-[assembly: AssemblyTitle("Casey.TraySystemMonitor.Ext")]
-#if DEBUG
-[assembly: AssemblyDescription("Externally viewable assembly for TraySystemMonitor.  Debug build.")]
-#else
-[assembly: AssemblyDescription("Externally viewable assembly for TraySystemMonitor.  Release build.")]
-#endif
-[assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("Casey Liss")]
-[assembly: AssemblyProduct("Casey.TraySystemMonitor.Ext")]
-[assembly: AssemblyCopyright("Copyright © Casey Liss 2007-2015")]
-[assembly: AssemblyTrademark("")]
-[assembly: AssemblyCulture("")]
-
 // Setting ComVisible to false makes the types in this assembly not visible 
 // to COM components.  If you need to access a type in this assembly from 
 // COM, set the ComVisible attribute to true on that type.
@@ -25,15 +9,3 @@ using System.Runtime.InteropServices;
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("9db7729d-6e75-408d-a450-7cd328f1a1de")]
-
-// Version information for an assembly consists of the following four values:
-//
-//      Major Version
-//      Minor Version 
-//      Build Number
-//      Revision
-//
-// You can specify all the values or you can default the Revision and Build Numbers 
-// by using the '*' as shown below:
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/Casey.TraySystemMonitor.Gui/Casey.TraySystemMonitor.Gui.csproj
+++ b/Casey.TraySystemMonitor.Gui/Casey.TraySystemMonitor.Gui.csproj
@@ -1,23 +1,11 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="12.0">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <ProductVersion>8.0.50727</ProductVersion>
-    <SchemaVersion>2.0</SchemaVersion>
-    <ProjectGuid>{2EBC9981-57DC-4468-9266-FDF3CEBFD303}</ProjectGuid>
     <OutputType>WinExe</OutputType>
-    <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>Casey.TraySystemMonitor.Gui</RootNamespace>
-    <AssemblyName>Casey.TraySystemMonitor.Gui</AssemblyName>
     <ApplicationIcon>App.ico</ApplicationIcon>
-    <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
-    <FileUpgradeFlags>
-    </FileUpgradeFlags>
-    <UpgradeBackupLocation>
-    </UpgradeBackupLocation>
-    <OldToolsVersion>2.0</OldToolsVersion>
-    <TargetFrameworkProfile />
+    <TargetFramework>net451</TargetFramework>
+    <FileUpgradeFlags />
+    <UpgradeBackupLocation />
     <IsWebBootstrapper>false</IsWebBootstrapper>
     <PublishUrl>publish\</PublishUrl>
     <Install>true</Install>
@@ -33,99 +21,59 @@
     <ApplicationVersion>1.0.0.%2a</ApplicationVersion>
     <UseApplicationTrust>false</UseApplicationTrust>
     <BootstrapperEnabled>true</BootstrapperEnabled>
+    <AssemblyTitle>Casey.TraySystemMonitor.Gui</AssemblyTitle>
+    <Company>Casey Liss</Company>
+    <Product>Casey.TraySystemMonitor.Gui</Product>
+    <Description>Application to monitor your system resources.  Release build.</Description>
+    <Copyright>Copyright © Casey Liss 2007-2015</Copyright>
+    <OutputPath>bin\$(Configuration)\</OutputPath>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
-    <Optimize>false</Optimize>
-    <OutputPath>bin\Debug\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-    <Prefer32Bit>false</Prefer32Bit>
     <PlatformTarget>x86</PlatformTarget>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
-    <Optimize>true</Optimize>
-    <OutputPath>bin\Release\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="System" />
-    <Reference Include="System.Drawing" />
     <Reference Include="System.Windows.Forms" />
-    <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="MainForm.cs">
+    <Compile Update="MainForm.cs">
       <SubType>Form</SubType>
     </Compile>
-    <Compile Include="MainForm.Designer.cs">
+    <Compile Update="MainForm.Designer.cs">
       <DependentUpon>MainForm.cs</DependentUpon>
     </Compile>
-    <Compile Include="Preferences.cs" />
-    <Compile Include="Program.cs" />
-    <Compile Include="Properties\AssemblyInfo.cs" />
-    <EmbeddedResource Include="MainForm.resx">
+    <EmbeddedResource Update="MainForm.resx">
       <SubType>Designer</SubType>
       <DependentUpon>MainForm.cs</DependentUpon>
     </EmbeddedResource>
-    <EmbeddedResource Include="Properties\Resources.resx">
+    <EmbeddedResource Update="Properties\Resources.resx">
       <Generator>ResXFileCodeGenerator</Generator>
       <LastGenOutput>Resources.Designer.cs</LastGenOutput>
       <SubType>Designer</SubType>
     </EmbeddedResource>
-    <Compile Include="Properties\Resources.Designer.cs">
+    <Compile Update="Properties\Resources.Designer.cs">
       <AutoGen>True</AutoGen>
       <DependentUpon>Resources.resx</DependentUpon>
       <DesignTime>True</DesignTime>
     </Compile>
-    <None Include="app.config" />
     <None Include="Properties\Settings.settings">
       <Generator>SettingsSingleFileGenerator</Generator>
       <LastGenOutput>Settings.Designer.cs</LastGenOutput>
     </None>
-    <Compile Include="Properties\Settings.Designer.cs">
+    <Compile Update="Properties\Settings.Designer.cs">
       <AutoGen>True</AutoGen>
       <DependentUpon>Settings.settings</DependentUpon>
       <DesignTimeSharedInput>True</DesignTimeSharedInput>
     </Compile>
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\Casey.TraySystemMonitor.Biz\Casey.TraySystemMonitor.Biz.csproj">
-      <Project>{7578B6FE-B524-4CC1-A67C-CAC9E4429170}</Project>
-      <Name>Casey.TraySystemMonitor.Biz</Name>
-    </ProjectReference>
-    <ProjectReference Include="..\Casey.TraySystemMonitor.Ext\Casey.TraySystemMonitor.Ext.csproj">
-      <Project>{96AC9B73-477A-4F57-804B-4D0C2E415E13}</Project>
-      <Name>Casey.TraySystemMonitor.Ext</Name>
-    </ProjectReference>
+    <ProjectReference Include="..\Casey.TraySystemMonitor.Biz\Casey.TraySystemMonitor.Biz.csproj" />
+    <ProjectReference Include="..\Casey.TraySystemMonitor.Ext\Casey.TraySystemMonitor.Ext.csproj" />
   </ItemGroup>
   <ItemGroup>
     <Content Include="App.ico" />
   </ItemGroup>
-  <ItemGroup>
-    <BootstrapperPackage Include="Microsoft.Net.Client.3.5">
-      <Visible>False</Visible>
-      <ProductName>.NET Framework 3.5 SP1 Client Profile</ProductName>
-      <Install>false</Install>
-    </BootstrapperPackage>
-    <BootstrapperPackage Include="Microsoft.Net.Framework.3.5.SP1">
-      <Visible>False</Visible>
-      <ProductName>.NET Framework 3.5 SP1</ProductName>
-      <Install>true</Install>
-    </BootstrapperPackage>
-  </ItemGroup>
-  <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
-  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
-       Other similar extension points exist, see Microsoft.Common.targets.
-  <Target Name="BeforeBuild">
-  </Target>
-  <Target Name="AfterBuild">
-  </Target>
-  -->
 </Project>

--- a/Casey.TraySystemMonitor.Gui/Casey.TraySystemMonitor.Gui.csproj
+++ b/Casey.TraySystemMonitor.Gui/Casey.TraySystemMonitor.Gui.csproj
@@ -1,9 +1,9 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   <PropertyGroup>
     <ProductVersion>8.0.50727</ProductVersion>
     <OutputType>WinExe</OutputType>
     <ApplicationIcon>App.ico</ApplicationIcon>
-    <TargetFramework>net451</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <FileUpgradeFlags />
     <UpgradeBackupLocation />
     <IsWebBootstrapper>false</IsWebBootstrapper>
@@ -27,6 +27,7 @@
     <Description>Application to monitor your system resources.  Release build.</Description>
     <Copyright>Copyright © Casey Liss 2007-2015</Copyright>
     <OutputPath>bin\$(Configuration)\</OutputPath>
+    <UseWindowsForms>true</UseWindowsForms>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugType>full</DebugType>
@@ -36,12 +37,7 @@
     <DebugType>pdbonly</DebugType>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="System.Windows.Forms" />
-  </ItemGroup>
-  <ItemGroup>
-    <Compile Update="MainForm.cs">
-      <SubType>Form</SubType>
-    </Compile>
+    <Compile Update="MainForm.cs" />
     <Compile Update="MainForm.Designer.cs">
       <DependentUpon>MainForm.cs</DependentUpon>
     </Compile>
@@ -72,6 +68,7 @@
   <ItemGroup>
     <ProjectReference Include="..\Casey.TraySystemMonitor.Biz\Casey.TraySystemMonitor.Biz.csproj" />
     <ProjectReference Include="..\Casey.TraySystemMonitor.Ext\Casey.TraySystemMonitor.Ext.csproj" />
+    <PackageReference Include="System.Resources.Extensions" Version="4.7.1" />
   </ItemGroup>
   <ItemGroup>
     <Content Include="App.ico" />

--- a/Casey.TraySystemMonitor.Gui/MainForm.cs
+++ b/Casey.TraySystemMonitor.Gui/MainForm.cs
@@ -83,8 +83,9 @@ namespace Casey.TraySystemMonitor.Gui
             // Establish the context menu
             if (!_prefs.FancyMenu)
             {
-                _notifyIcon.ContextMenu = new ContextMenu();
-                _notifyIcon.ContextMenu.Popup += OnContextMenuPopUp;
+                throw new NotSupportedException("Currently not supported in .NET Core");
+                //_notifyIcon.ContextMenu = new ContextMenu();
+                //_notifyIcon.ContextMenu.Popup += OnContextMenuPopUp;
             }
             else
             {
@@ -141,29 +142,30 @@ namespace Casey.TraySystemMonitor.Gui
         /// <param name="e">Event arguments</param>
         void OnContextMenuPopUp(object sender, EventArgs e)
         {
-            ContextMenu trayMenu = _notifyIcon.ContextMenu;
-            trayMenu.MenuItems.Clear();
+            throw new NotSupportedException("Currently not supported in .NET Core");
+            //ContextMenu trayMenu = _notifyIcon.ContextMenu;
+            //trayMenu.MenuItems.Clear();
 
-            // Fill the available providers
-            MenuItem left = new MenuItem("Left");
-            MenuItem right = new MenuItem("Right");
-            AddMenuItems(left, MenuTag.DisplaySide.Left, _left);
-            AddMenuItems(right, MenuTag.DisplaySide.Right, _right);
+            //// Fill the available providers
+            //MenuItem left = new MenuItem("Left");
+            //MenuItem right = new MenuItem("Right");
+            //AddMenuItems(left, MenuTag.DisplaySide.Left, _left);
+            //AddMenuItems(right, MenuTag.DisplaySide.Right, _right);
 
-            // Left/right sides and separator
-            trayMenu.MenuItems.Add(left);
-            trayMenu.MenuItems.Add(right);
-            trayMenu.MenuItems.Add("-");
+            //// Left/right sides and separator
+            //trayMenu.MenuItems.Add(left);
+            //trayMenu.MenuItems.Add(right);
+            //trayMenu.MenuItems.Add("-");
 
-            // Center line
-            MenuItem center = new MenuItem("Center line", new EventHandler(OnCenterlineMenuClick));
-            center.Checked = _prefs.Centerline;
-            trayMenu.MenuItems.Add(center);
-            trayMenu.MenuItems.Add("-");
+            //// Center line
+            //MenuItem center = new MenuItem("Center line", new EventHandler(OnCenterlineMenuClick));
+            //center.Checked = _prefs.Centerline;
+            //trayMenu.MenuItems.Add(center);
+            //trayMenu.MenuItems.Add("-");
 
-            // About/Exit
-            trayMenu.MenuItems.Add(new MenuItem("&About", new EventHandler(OnAboutMenuClick)));
-            trayMenu.MenuItems.Add(new MenuItem("E&xit", new EventHandler(OnExitMenuClick)));
+            //// About/Exit
+            //trayMenu.MenuItems.Add(new MenuItem("&About", new EventHandler(OnAboutMenuClick)));
+            //trayMenu.MenuItems.Add(new MenuItem("E&xit", new EventHandler(OnExitMenuClick)));
         }
 
         /// <summary>
@@ -173,12 +175,13 @@ namespace Casey.TraySystemMonitor.Gui
         /// <param name="e">Event arguments</param>
         void OnProviderMenuItemClick(object sender, EventArgs e)
         {
-            MenuItem item = sender as MenuItem;
-            if (item != null)
-            {
-                MenuTag tag = item.Tag as MenuTag;
-                HandleProviderSwitch(tag);
-            }
+            throw new NotSupportedException("Currently not supported in .NET Core");
+            //MenuItem item = sender as MenuItem;
+            //if (item != null)
+            //{
+            //    MenuTag tag = item.Tag as MenuTag;
+            //    HandleProviderSwitch(tag);
+            //}
         }
 
         /// <summary>
@@ -303,13 +306,14 @@ namespace Casey.TraySystemMonitor.Gui
         /// <param name="e">Event arguments</param>
         void OnCenterlineMenuClick(object sender, EventArgs e)
         {
-            MenuItem item = sender as MenuItem;
-            if (item != null)
-            {
-                // Note the Checked property hasn't changed yet.
-                _prefs.Centerline = !item.Checked;
-                UpdatePreferences();
-            }
+            throw new NotSupportedException("Currently not supported in .NET Core");
+            //MenuItem item = sender as MenuItem;
+            //if (item != null)
+            //{
+            //    // Note the Checked property hasn't changed yet.
+            //    _prefs.Centerline = !item.Checked;
+            //    UpdatePreferences();
+            //}
         }
 
         /// <summary>
@@ -328,28 +332,28 @@ namespace Casey.TraySystemMonitor.Gui
             }
         }
 
-        /// <summary>
-        /// Adds all the providers to the given menu
-        /// </summary>
-        /// <param name="root">Root menu item</param>
-        /// <param name="side">Which side we're on</param>
-        /// <param name="current">Current status provider on this side</param>
-        void AddMenuItems(
-           MenuItem root,
-           MenuTag.DisplaySide side,
-           EXT.IStatusProvider current)
-        {
-            foreach (EXT.IStatusProvider provider in _providers)
-            {
-                MenuItem item = new MenuItem(provider.Name);
-                item.Tag = new MenuTag(side, provider);
-                item.Checked = ReferenceEquals(current, provider);
-                item.Enabled = !ReferenceEquals(current, provider);
-                item.Click += OnProviderMenuItemClick;
+        ///// <summary>
+        ///// Adds all the providers to the given menu
+        ///// </summary>
+        ///// <param name="root">Root menu item</param>
+        ///// <param name="side">Which side we're on</param>
+        ///// <param name="current">Current status provider on this side</param>
+        //void AddMenuItems(
+        //   MenuItem root,
+        //   MenuTag.DisplaySide side,
+        //   EXT.IStatusProvider current)
+        //{
+        //    foreach (EXT.IStatusProvider provider in _providers)
+        //    {
+        //        MenuItem item = new MenuItem(provider.Name);
+        //        item.Tag = new MenuTag(side, provider);
+        //        item.Checked = ReferenceEquals(current, provider);
+        //        item.Enabled = !ReferenceEquals(current, provider);
+        //        item.Click += OnProviderMenuItemClick;
 
-                root.MenuItems.Add(item);
-            }
-        }
+        //        root.MenuItems.Add(item);
+        //    }
+        //}
 
         /// <summary>
         /// Adds all the providers to the given menu

--- a/Casey.TraySystemMonitor.Gui/Properties/AssemblyInfo.cs
+++ b/Casey.TraySystemMonitor.Gui/Properties/AssemblyInfo.cs
@@ -2,22 +2,6 @@
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
-// General Information about an assembly is controlled through the following 
-// set of attributes. Change these attribute values to modify the information
-// associated with an assembly.
-[assembly: AssemblyTitle("Casey.TraySystemMonitor.Gui")]
-#if DEBUG
-[assembly: AssemblyDescription("Application to monitor your system resources.  Debug build.")]
-#else
-[assembly: AssemblyDescription("Application to monitor your system resources.  Release build.")]
-#endif
-[assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("Casey Liss")]
-[assembly: AssemblyProduct("Casey.TraySystemMonitor.Gui")]
-[assembly: AssemblyCopyright("Copyright © Casey Liss 2007-2015")]
-[assembly: AssemblyTrademark("")]
-[assembly: AssemblyCulture("")]
-
 // Setting ComVisible to false makes the types in this assembly not visible 
 // to COM components.  If you need to access a type in this assembly from 
 // COM, set the ComVisible attribute to true on that type.
@@ -25,13 +9,3 @@ using System.Runtime.InteropServices;
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("d68d878c-8d3f-4a91-9c8d-236f0e64d0ca")]
-
-// Version information for an assembly consists of the following four values:
-//
-//      Major Version
-//      Minor Version 
-//      Build Number
-//      Revision
-//
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/Casey.Utility/Casey.Utility.csproj
+++ b/Casey.Utility/Casey.Utility.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net451</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <AssemblyTitle>Casey.Utility</AssemblyTitle>
     <Company>Microsoft</Company>
     <Product>Casey.Utility</Product>
@@ -15,7 +15,6 @@
     <DebugType>pdbonly</DebugType>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="System.Data.DataSetExtensions" />
-    <Reference Include="Microsoft.CSharp" />
+    <PackageReference Include="System.Drawing.Common" Version="4.7.0" />
   </ItemGroup>
 </Project>

--- a/Casey.Utility/Casey.Utility.csproj
+++ b/Casey.Utility/Casey.Utility.csproj
@@ -1,56 +1,21 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProjectGuid>{22502482-4566-4670-9D6B-8E264810EEA3}</ProjectGuid>
-    <OutputType>Library</OutputType>
-    <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>Casey.Utility</RootNamespace>
-    <AssemblyName>Casey.Utility</AssemblyName>
-    <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
-    <FileAlignment>512</FileAlignment>
-    <TargetFrameworkProfile />
+    <TargetFramework>net451</TargetFramework>
+    <AssemblyTitle>Casey.Utility</AssemblyTitle>
+    <Company>Microsoft</Company>
+    <Product>Casey.Utility</Product>
+    <Copyright>Copyright © Microsoft 2015</Copyright>
+    <OutputPath>bin\$(Configuration)\</OutputPath>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
-    <Optimize>false</Optimize>
-    <OutputPath>bin\Debug\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
     <PlatformTarget>x86</PlatformTarget>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
-    <Optimize>true</Optimize>
-    <OutputPath>bin\Release\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="System" />
-    <Reference Include="System.Core" />
-    <Reference Include="System.Drawing" />
-    <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />
-    <Reference Include="System.Data" />
-    <Reference Include="System.Xml" />
   </ItemGroup>
-  <ItemGroup>
-    <Compile Include="Properties\AssemblyInfo.cs" />
-    <Compile Include="ResourceManager.cs" />
-  </ItemGroup>
-  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
-       Other similar extension points exist, see Microsoft.Common.targets.
-  <Target Name="BeforeBuild">
-  </Target>
-  <Target Name="AfterBuild">
-  </Target>
-  -->
 </Project>

--- a/Casey.Utility/Properties/AssemblyInfo.cs
+++ b/Casey.Utility/Properties/AssemblyInfo.cs
@@ -2,18 +2,6 @@
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
-// General Information about an assembly is controlled through the following 
-// set of attributes. Change these attribute values to modify the information
-// associated with an assembly.
-[assembly: AssemblyTitle("Casey.Utility")]
-[assembly: AssemblyDescription("")]
-[assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("Microsoft")]
-[assembly: AssemblyProduct("Casey.Utility")]
-[assembly: AssemblyCopyright("Copyright © Microsoft 2015")]
-[assembly: AssemblyTrademark("")]
-[assembly: AssemblyCulture("")]
-
 // Setting ComVisible to false makes the types in this assembly not visible 
 // to COM components.  If you need to access a type in this assembly from 
 // COM, set the ComVisible attribute to true on that type.
@@ -21,16 +9,3 @@ using System.Runtime.InteropServices;
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("70b5fb6b-bb26-4391-a32a-a667c414a00c")]
-
-// Version information for an assembly consists of the following four values:
-//
-//      Major Version
-//      Minor Version 
-//      Build Number
-//      Revision
-//
-// You can specify all the values or you can default the Build and Revision Numbers 
-// by using the '*' as shown below:
-// [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]


### PR DESCRIPTION
(This won't actually make it cross-platform; it still depends on Windows-only WinForms.)

This compiles and runs, but I removed/disabled the `MenuItem` code for now. That class has been deprecated since .NET Framework 2.0 and was killed altogether in .NET Core 3.1.

My guess is `if (!_prefs.FancyMenu)` only exists for backwards compat anyway, but maybe @cliss remembers?